### PR TITLE
Fixed multiple newcite

### DIFF
--- a/assets/files/naaclhlt2016-latex/naaclhlt2016.sty
+++ b/assets/files/naaclhlt2016-latex/naaclhlt2016.sty
@@ -423,7 +423,7 @@
 % otherwise like \shortcite.
 \def\@citexb[#1]#2{\if@filesw\immediate\write\@auxout{\string\citation{#2}}\fi
   \def\@citea{}\@newcite{\@for\@citeb:=#2\do
-    {\@citea\def\@citea{;\penalty\@m\ }\@ifundefined
+    {\@citea\def\@citea{);\penalty\@m\ }\@ifundefined
        {b@\@citeb}{{\bf ?}\@warning
        {Citation `\@citeb' on page \thepage \space undefined}}%
 {\csname b@\@citeb\endcsname}}}{#1}}


### PR DESCRIPTION
Fixed a missing closing bracket ')' for the case of a `newcite` with multiple citations
(It happened for all but the last citations)
